### PR TITLE
refactor(snap): Replace `exit(1)` with `fatal`

### DIFF
--- a/snap/local/hooks/cmd/configure/configure.go
+++ b/snap/local/hooks/cmd/configure/configure.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"os"
 	"strings"
 
 	"github.com/canonical/edgex-snap-hooks/v2/log"
@@ -31,15 +30,13 @@ func main() {
 	log.Info("Enabling config options")
 	err := snapctl.Set("app-options", "true").Run()
 	if err != nil {
-		log.Errorf("could not enable config options: %v", err)
-		os.Exit(1)
+		log.Fatalf("could not enable config options: %v", err)
 	}
 
 	log.Info("Processing options")
 	err = options.ProcessAppConfig("device-virtual")
 	if err != nil {
-		log.Errorf("could not process options: %v", err)
-		os.Exit(1)
+		log.Fatalf("could not process options: %v", err)
 	}
 
 	// If autostart is not explicitly set, default to "no"
@@ -47,8 +44,7 @@ func main() {
 	// are provided by default.
 	autostart, err := snapctl.Get("autostart").Run()
 	if err != nil {
-		log.Errorf("Reading config 'autostart' failed: %v", err)
-		os.Exit(1)
+		log.Fatalf("Reading config 'autostart' failed: %v", err)
 	}
 	if autostart == "" {
 		log.Debug("autostart is NOT set, initializing to 'no'")
@@ -62,13 +58,11 @@ func main() {
 	case "true", "yes":
 		err = snapctl.Start("device-virtual").Enable().Run()
 		if err != nil {
-			log.Errorf("Can't start service: %s", err)
-			os.Exit(1)
+			log.Fatalf("Can't start service: %s", err)
 		}
 	case "false", "no":
 		// no action necessary
 	default:
-		log.Errorf("Invalid value for 'autostart': %s", autostart)
-		os.Exit(1)
+		log.Fatalf("Invalid value for 'autostart': %s", autostart)
 	}
 }

--- a/snap/local/hooks/cmd/install/install.go
+++ b/snap/local/hooks/cmd/install/install.go
@@ -69,19 +69,16 @@ func main() {
 
 	err := installConfig()
 	if err != nil {
-		log.Errorf("error installing config file: %s", err)
-		os.Exit(1)
+		log.Fatalf("error installing config file: %s", err)
 	}
 
 	err = installDevices()
 	if err != nil {
-		log.Errorf("error installing devices config: %s", err)
-		os.Exit(1)
+		log.Fatalf("error installing devices config: %s", err)
 	}
 
 	err = installDevProfiles()
 	if err != nil {
-		log.Errorf("error installing device profiles config: %s", err)
-		os.Exit(1)
+		log.Fatalf("error installing device profiles config: %s", err)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Mengyi Wang <mengyi.wang@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-virtual-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-virtual-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->